### PR TITLE
FIX: Build on Darwin 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,23 @@ endif
 
 CXX      := g++
 CXXFLAGS := -pthread -fno-strict-aliasing -std=c++0x -pedantic -Wall
-LDFLAGS  := -L/opt/local/lib
-LIBS     := -lpthread -lm 
+LIBS     := -lpthread -lm -ljack -lrtmidi
 .PHONY: all release debian-release info debug clean debian-clean distclean 
 DESTDIR := /
 PREFIX := /usr/local
 MACHINE := $(shell uname -m)
 
+ifeq ($(UNAME_S), Linux)
+	LDFLAGS  := -L/opt/local/lib
+endif
+
 ifeq ($(UNAME_S), Darwin)
- CXX=clang++
- LD=clang++
- LDFLAGS += -L/opt/local/lib # MacPorts Boost doesn't come with pkgconfig
- CXXFLAGS += -stdlib=libc++ 
- LDFLAGS += -stdlib=libc++ 
+ 	CXX=clang++
+	LD=clang++
+	LIBS += -lboost_system-mt -lboost_program_options-mt -lAquila -lOoura_fft -lsamplerate
+	LDFLAGS +=  -L`brew --prefix jack`/lib -L`brew --prefix rtmidi`/lib -L`brew --prefix libsamplerate`/lib
+	CXXFLAGS += -stdlib=libc++ -I`brew --prefix jack`/include/jack -I`brew --prefix rtmidi`/include -I`brew --prefix libsamplerate`/include
+	LDFLAGS += -stdlib=libc++ 
 endif
 
 ifeq ($(MACHINE), x86_64)

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,9 +5,23 @@ TARGET := pitchDetect.html
 endif
 
 SRCS  := pitchDetect.cpp jackrecorder.cpp
-CXXFLAGS += `pkg-config --cflags sndfile samplerate jack rtmidi` -I../third/aquila/
-LIBS +=  `pkg-config --libs sndfile samplerate jack rtmidi` -lboost_program_options -lAquila -lOoura_fft
+
 LDFLAGS += -L../third/aquila/ -L../third/aquila/lib
+CXXFLAGS += -I../third/aquila/
+
+ifeq ($(UNAME_S), Linux)
+	CXXFLAGS += `pkg-config --cflags sndfile samplerate jack rtmidi` -I../third/aquila/
+	LIBS +=  `pkg-config --libs sndfile samplerate jack rtmidi` -lboost_program_options -lAquila -lOoura_fft
+endif
+
+ifeq ($(UNAME_S), Darwin)
+ 	CXX=clang++
+	LD=clang++
+	CXXFLAGS += `pkg-config --cflags sndfile samplerate` -I`brew --prefix jack`/jack/include -I`brew --prefix rtmidi`/include -I../third/aquila/
+	LDFLAGS += -L`brew --prefix jack`/lib -L`brew --prefix rtmidi`/lib  -L`brew --prefix boost`/lib -L../third/aquila -L../third/aquila/lib
+	LIBS +=  `pkg-config --libs sndfile samplerate` -lboost -ljack -lrtmidi -lboost_program_options -lAquila -lOoura_fft
+endif
+
 
 #precompiled headers
 HEADERS := 

--- a/src/pitchDetect.cpp
+++ b/src/pitchDetect.cpp
@@ -6,7 +6,7 @@
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 #include <samplerate.h>
-#include <rtmidi/RtMidi.h>
+#include <RtMidi.h>
 #define _USE_MATH_DEFINES
 #include <cmath>
 #include <limits>


### PR DESCRIPTION
Note:
* MacOS Mojave 10.14.5
* Requires: 
`brew install libsamplerate jack rtmidi boost`
* Changes ref to 'rtMidi.h' globally 